### PR TITLE
feat: add support to WITH statements

### DIFF
--- a/internal/knowledge/query_sql.go
+++ b/internal/knowledge/query_sql.go
@@ -138,6 +138,13 @@ func buildSQLConstraintsFromPatterns(queryGraph *QueryGraph, constrainedNodes ma
 			alias = fmt.Sprintf("a%d", i)
 		}
 
+		queryGraphNode, err := queryGraph.GetNodeByID(n.id)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		queryGraphNode.AssignedVariable = alias
+
 		// If no relationship of this node has been visited yet, then we have no information on this node.
 		// Scan the assets table again for this particular node.
 		if !relationToAssetExists {
@@ -228,6 +235,9 @@ func buildSQLConstraintsFromPatterns(queryGraph *QueryGraph, constrainedNodes ma
 				assetAliasPrefix = "a"
 			}
 			ralias = fmt.Sprintf("%s%d", aliasPrefix, relationCount)
+
+			relation.AssignedVariable = ralias
+
 			relationCount++
 			var exps []string
 
@@ -308,7 +318,6 @@ func buildSQLConstraintsFromPatterns(queryGraph *QueryGraph, constrainedNodes ma
 func (sqt *SQLQueryTranslator) Translate(query *query.QueryCypher) (*SQLTranslation, error) {
 	constrainedNodes := make(map[int]bool)
 
-	filterExpressions := AndOrExpression{And: true}
 	whereExpressions := AndOrExpression{And: true}
 	for _, x := range query.QuerySinglePartQuery.QueryMatches {
 		parser := NewPatternParser(&sqt.QueryGraph)
@@ -349,12 +358,10 @@ func (sqt *SQLQueryTranslator) Translate(query *query.QueryCypher) (*SQLTranslat
 	}
 	from := f
 
-	if whereExpressions.Expression != "" || len(whereExpressions.Children) > 0 {
-		filterExpressions.Children = append(filterExpressions.Children, whereExpressions) // CQL where conditions
-	}
-
 	projections := make([]SQLProjection, 0)
 	projectionTypes := make([]Projection, 0)
+	havingExpressions := AndOrExpression{And: true}
+	functionedAliases := make(map[string]struct{})
 	groupByIndices := []int{}
 	groupByRequired := false
 	variableIndices := []int{}
@@ -385,6 +392,83 @@ func (sqt *SQLQueryTranslator) Translate(query *query.QueryCypher) (*SQLTranslat
 			ExpressionType: projectionVisitor.ExpressionType,
 		})
 	}
+
+	// Project with statements
+
+	for _, w := range query.QuerySinglePartQuery.WithProjections {
+		for _, p := range w.ProjectionBody.ProjectionItems {
+			// Project variables
+			projectionVisitor := NewProjectionVisitor(&sqt.QueryGraph)
+			err := projectionVisitor.ParseExpression(&p.Expression)
+			if err != nil {
+				return nil, err
+			}
+			sqt.QueryGraph.PushProperty(p.Alias)
+			for _, proj := range projectionVisitor.Projections {
+				if proj.Function != "" {
+					projections = append(projections, SQLProjection{
+						Function: &SQLFunction{Name: proj.Function, Distinct: proj.Distinct},
+						Variable: proj.Variable,
+						Alias:    p.Alias})
+					functionedAliases[proj.Variable[:strings.IndexByte(proj.Variable, '.')]] = struct{}{}
+					groupByRequired = true
+				} else if proj.Variable != "" {
+					projections = append(projections, SQLProjection{Variable: proj.Variable})
+				} else {
+					return nil, fmt.Errorf("Unable to detect type of projection")
+				}
+			}
+
+			projectionTypes = append(projectionTypes, Projection{
+				Alias:          p.Alias,
+				ExpressionType: projectionVisitor.ExpressionType,
+			})
+		}
+
+		// Include where statements
+
+		if w.Where != nil {
+			whereVisitor := NewQueryWhereVisitor(&sqt.QueryGraph) // having conditions of the with statements
+			havingExpression, err := whereVisitor.ParseExpression(w.Where)
+			if err != nil {
+				return nil, err
+			}
+			for _, v := range whereVisitor.Variables {
+				typeAndIndex, err := sqt.QueryGraph.FindVariable(v)
+				if err != nil {
+					return nil, err
+				}
+				constrainedNodes[typeAndIndex.Index] = true
+			}
+
+			// We only append the expression if it's not empty
+			if havingExpression != "" {
+				havingExpressions.Children = append(havingExpressions.Children,
+					AndOrExpression{And: true, Expression: havingExpression})
+			}
+		}
+
+	}
+
+	// If a relationship projection is a functioned one, then we need to propragate a left join to it's later node to find null values
+	for _, relation := range sqt.QueryGraph.Relations {
+		_, ok := functionedAliases[relation.AssignedVariable]
+		if !ok {
+			continue
+		}
+
+		index := relation.LeftIdx
+		if relation.RightIdx > relation.LeftIdx {
+			index = relation.RightIdx
+		}
+
+		n, err := sqt.QueryGraph.GetNodeByID(index)
+		if err != nil {
+			return nil, err
+		}
+		functionedAliases[n.AssignedVariable] = struct{}{}
+	}
+
 	// If group by is required, we group by all variables except the aggregation functions
 	if groupByRequired {
 		groupByIndices = variableIndices
@@ -418,14 +502,16 @@ func (sqt *SQLQueryTranslator) Translate(query *query.QueryCypher) (*SQLTranslat
 	var sqlQuery string
 
 	innerSQL := SQLStructure{
-		Distinct:        query.QuerySinglePartQuery.ProjectionBody.Distinct,
-		Projections:     projections,
-		FromEntries:     from,
-		WhereExpression: whereExpressions,
-		JoinEntries:     joins,
-		GroupByIndices:  groupByIndices,
-		Limit:           limit,
-		Offset:          offset,
+		Distinct:          query.QuerySinglePartQuery.ProjectionBody.Distinct,
+		Projections:       projections,
+		FromEntries:       from,
+		WhereExpression:   whereExpressions,
+		HavingExpression:  havingExpressions,
+		FunctionedAliases: functionedAliases,
+		JoinEntries:       joins,
+		GroupByIndices:    groupByIndices,
+		Limit:             limit,
+		Offset:            offset,
 	}
 
 	sqlQuery, err = buildSQLSelect(innerSQL)

--- a/internal/knowledge/query_sql_test.go
+++ b/internal/knowledge/query_sql_test.go
@@ -434,6 +434,55 @@ func TestQueryTranslation(t *testing.T) {
 			JOIN assets a5 ON a5.type = 'ldap_group' AND r4.to_id = a5.id
 			`,
 		},
+		{
+			Cypher: `
+			MATCH (ldap_group:ldap_group)<-[r:member_of]-()
+			WITH COUNT(r) AS c WHERE c = 0
+			RETURN ldap_group`,
+			SQL: `
+			SELECT a0.id, a0.value, a0.type, COUNT(r0.id) AS c
+			FROM (assets a0_0)
+			JOIN assets a0 ON a0.type = 'ldap_group' AND a0.id = a0_0.id
+			LEFT JOIN relations r0 ON r0.type = 'member_of' AND r0.to_id = a0.id
+			LEFT JOIN assets a1 ON r0.from_id = a1.id
+			GROUP BY a0.id, a0.value, a0.type
+			HAVING c = 0
+			`,
+		},
+		{
+			Cypher: `
+			MATCH (ldap_group:ldap_group)<-[r:member_of]-(:user)
+			WITH COUNT(r) AS c WHERE c = 0
+			RETURN ldap_group`,
+			SQL: `
+			SELECT a0.id, a0.value, a0.type, COUNT(r0.id) AS c
+			FROM (assets a0_0)
+			JOIN assets a0 ON a0.type = 'ldap_group' AND a0.id = a0_0.id
+			LEFT JOIN relations r0 ON r0.type = 'member_of' AND r0.to_id = a0.id
+			LEFT JOIN assets a1 ON a1.type = 'user' AND r0.from_id = a1.id
+			GROUP BY a0.id, a0.value, a0.type
+			HAVING c = 0
+			`,
+		},
+		{
+			Cypher: `
+			MATCH (ldap_group:ldap_group)<-[r:member_of]-()
+			WHERE ldap_group.value <> "something"
+			WITH COUNT(r) AS c
+			WHERE c = 0
+			RETURN ldap_group
+			`,
+			SQL: `
+			SELECT a0.id, a0.value, a0.type, COUNT(r0.id) AS c
+			FROM (assets a0_0)
+			JOIN assets a0 ON a0.type = 'ldap_group' AND a0.id = a0_0.id
+			LEFT JOIN relations r0 ON r0.type = 'member_of' AND r0.to_id = a0.id
+			LEFT JOIN assets a1 ON r0.from_id = a1.id
+			WHERE a0.value <> 'something'
+			GROUP BY a0.id, a0.value, a0.type
+			HAVING c = 0
+			`,
+		},
 	}
 
 	selectionEnabled := false

--- a/internal/knowledge/sql_builder_test.go
+++ b/internal/knowledge/sql_builder_test.go
@@ -16,7 +16,7 @@ func TestBuildBasicSingleSQLSelect_Distinct(t *testing.T) {
 				[]SQLJoin{},
 				[]SQLInnerStructure{},
 				AndOrExpression{},
-				[]int{}, 0, 0)
+				[]int{}, AndOrExpression{}, map[string]struct{}{}, 0, 0)
 
 			assert.NoError(t, err)
 			assert.Equal(t, expected, sql)
@@ -35,7 +35,7 @@ func TestBuildBasicSingleSQLSelect_FromAlias(t *testing.T) {
 		[]SQLJoin{},
 		[]SQLInnerStructure{},
 		AndOrExpression{},
-		[]int{}, 0, 0)
+		[]int{}, AndOrExpression{}, map[string]struct{}{}, 0, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "SELECT *\nFROM (asset, relation r0)", sql)
@@ -49,7 +49,7 @@ func TestBuildBasicSingleSQLSelect_ProjectionAlias(t *testing.T) {
 		[]SQLJoin{},
 		[]SQLInnerStructure{},
 		AndOrExpression{},
-		[]int{}, 0, 0)
+		[]int{}, AndOrExpression{}, map[string]struct{}{}, 0, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "SELECT a0.id AS a0_id, a0.value\nFROM (asset a0)", sql)
@@ -68,7 +68,7 @@ func TestBuildBasicSingleSQLSelect_OrExpression(t *testing.T) {
 				{Expression: "a0_id = 'abc'"}, {Expression: "a0.type = 'mytype'"},
 			},
 		},
-		[]int{}, 0, 0)
+		[]int{}, AndOrExpression{}, map[string]struct{}{}, 0, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "SELECT *\nFROM (asset a0)\nWHERE a0_id = 'abc' OR a0.type = 'mytype'", sql)
@@ -87,7 +87,7 @@ func TestBuildBasicSingleSQLSelect_AndExpression(t *testing.T) {
 				{Expression: "a0_id = 'abc'"}, {Expression: "a0.type = 'mytype'"},
 			},
 		},
-		[]int{}, 0, 0)
+		[]int{}, AndOrExpression{}, map[string]struct{}{}, 0, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "SELECT *\nFROM (asset a0)\nWHERE a0_id = 'abc' AND a0.type = 'mytype'", sql)
@@ -109,7 +109,7 @@ func TestBuildBasicSingleSQLSelect_NestedExpressions(t *testing.T) {
 				},
 			},
 		},
-		[]int{}, 0, 0)
+		[]int{}, AndOrExpression{}, map[string]struct{}{}, 0, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "SELECT *\nFROM (asset a0)\nWHERE a0_id = 'abc' OR (a0.type = 'mytype' AND a0.value = 'myvalue')", sql)
@@ -123,7 +123,7 @@ func TestBuildBasicSingleSQLSelect_LIMIT(t *testing.T) {
 		[]SQLJoin{},
 		[]SQLInnerStructure{},
 		AndOrExpression{},
-		[]int{}, 10, 0)
+		[]int{}, AndOrExpression{}, map[string]struct{}{}, 10, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "SELECT *\nFROM (asset)\nLIMIT 10", sql)
@@ -137,7 +137,7 @@ func TestBuildBasicSingleSQLSelect_OFFSET(t *testing.T) {
 		[]SQLJoin{},
 		[]SQLInnerStructure{},
 		AndOrExpression{},
-		[]int{}, 10, 20)
+		[]int{}, AndOrExpression{}, map[string]struct{}{}, 10, 20)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "SELECT *\nFROM (asset)\nLIMIT 10\nOFFSET 20", sql)
@@ -151,10 +151,10 @@ func TestBuildBasicSingleSQLSelect_GroupBy(t *testing.T) {
 		[]SQLJoin{},
 		[]SQLInnerStructure{},
 		AndOrExpression{},
-		[]int{0, 2}, 0, 0)
+		[]int{0, 2}, AndOrExpression{}, map[string]struct{}{}, 0, 0)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "SELECT id, name, key\nFROM (asset)\nGROUP BY id, key", sql)
+	assert.Equal(t, "SELECT id, name, key\nFROM (asset)\nGROUP BY id, name", sql)
 }
 
 func TestBuildSQLSelect_UnwindOrExprIntoUnion(t *testing.T) {
@@ -195,7 +195,7 @@ func TestBuildSQLSelect_GroupBy_Limit_Offset(t *testing.T) {
 		})
 
 	assert.NoError(t, err)
-	assert.Equal(t, "SELECT id, name, key\nFROM (asset)\nWHERE id == 56 AND name == 'myname'\nGROUP BY id, key\nLIMIT 10\nOFFSET 20", sql)
+	assert.Equal(t, "SELECT id, name, key\nFROM (asset)\nWHERE id == 56 AND name == 'myname'\nGROUP BY id, name\nLIMIT 10\nOFFSET 20", sql)
 }
 
 func TestBuildBasicSingleSQLSelect_InnerSELECT(t *testing.T) {
@@ -216,7 +216,7 @@ func TestBuildBasicSingleSQLSelect_InnerSELECT(t *testing.T) {
 			},
 		},
 		AndOrExpression{And: true, Children: []AndOrExpression{{Expression: "s0.r_id > 8"}, {Expression: "a0.id = s0.r_from_id"}}},
-		[]int{}, 0, 0)
+		[]int{}, AndOrExpression{}, map[string]struct{}{}, 0, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "SELECT *\nFROM (asset a0, (SELECT id AS r_id, from_id AS r_from_id\nFROM (relations)\nWHERE type = 'mytype') AS s0)\nWHERE s0.r_id > 8 AND a0.id = s0.r_from_id", sql)
@@ -234,7 +234,7 @@ func TestBuildBasicSingleSQLSelect_JOIN(t *testing.T) {
 		}},
 		[]SQLInnerStructure{},
 		AndOrExpression{},
-		[]int{}, 0, 0)
+		[]int{}, AndOrExpression{}, map[string]struct{}{}, 0, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "SELECT *\nFROM (assets variable)\nJOIN assets a0 ON a0.type = 'variable' AND a0.id = variable.id", sql)
@@ -264,7 +264,7 @@ func TestBuildBasicSingleSQLSelect_JOINs(t *testing.T) {
 		},
 		[]SQLInnerStructure{},
 		AndOrExpression{},
-		[]int{}, 0, 0)
+		[]int{}, AndOrExpression{}, map[string]struct{}{}, 0, 0)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "SELECT *\nFROM (assets variable)\nJOIN assets a0 ON a0.type = 'variable' AND a0.id = variable.id\nJOIN relations r0 ON r0.type = 'is' AND r0.from_id = a0.id\nJOIN assets a1 ON a1.type = 'scope' AND r0.to_id = a1.id", sql)


### PR DESCRIPTION
* By using WITH statements it us possible to translate HAVING conditions. For example, now we can do this query to find teams with more than 10 members of any kind: `MATCH (team:team)<-[r:member_of]-() WITH COUNT(r) AS c WHERE c > 10 RETURN team`

* It is also possible to find nodes with no relationships by doing: `MATCH (team:team) WHERE NOT (team)<-[:member_of]-() RETURN team` or by doing
`MATCH (team:team)<-[r:member_of]-() WITH COUNT(r) AS c WHERE c = 0 RETURN team`

**Important limitation**
The Cypher parser considers the immediate WHERE statement after a MATCH and the immediate WHERE statement after a WITH differently. It creates a multipart query that are processed differently. For this use case, and since Criteo's implementation doesn't supported structured nodes, WITH statements should be used only for SQL functions (COUNT i.e), as the immediate WHERE condition is going to be translated to a SQL HAVING statement.

This was tested without the FORCE INDEX statement.